### PR TITLE
Updated the z-index to the max value for CSS

### DIFF
--- a/alert.js
+++ b/alert.js
@@ -1,7 +1,7 @@
 // alert.js
 
 var striped_lines_box = document.createElement('div');
-striped_lines_box.style.cssText = "background-image: url(https://i.imgur.com/m5Wjo7h.png); height: 20px;width: 100%;position: fixed; z-index: 99999; opacity: 0.7;";
+striped_lines_box.style.cssText = "background-image: url(https://i.imgur.com/m5Wjo7h.png); height: 20px;width: 100%;position: fixed; z-index: 2147483647; opacity: 0.7;";
 
 var inner_text = document.createElement('span');
 inner_text.textContent = "The information on this site might be false or misleading!";


### PR DESCRIPTION
Certain sites aren't showing the warning header because they have a `z-index` greater than 99999 somewhere in the DOM. This bumps the warning element's `z-index` to the maximum value allowed by chrome (2147483647 -- 2^31, the maximum value of a signed 32bit integer).