### PR TITLE
Allow user to choose between alert dialogs or banners.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8

--- a/alert.js
+++ b/alert.js
@@ -1,12 +1,23 @@
 // alert.js
 
-var striped_lines_box = document.createElement('div');
-striped_lines_box.style.cssText = "background-image: url(https://i.imgur.com/m5Wjo7h.png); height: 20px;width: 100%;position: fixed; z-index: 99999; opacity: 0.7;";
+var warning_text = "The information on this site might be false or misleading!";
 
-var inner_text = document.createElement('span');
-inner_text.textContent = "The information on this site might be false or misleading!";
-inner_text.style.cssText = "font-family: 'Lucida Console', Monaco, monospace; color: white; margin: auto; background: black; display: block; height: 20px; width: 500px; text-align: center; font-size: 14px;";
+// Read options to use either alrt dialog or banner
+chrome.storage.sync.get({
+  mode: 'banner' // Banner as default
+}, function(items) {
+  if (items.mode == 'alert') {
+    alert(warning_text);
+  } else if (items.mode == 'banner') {
+    var striped_lines_box = document.createElement('div');
+    striped_lines_box.style.cssText = "background-image: url(https://i.imgur.com/m5Wjo7h.png); height: 20px; width: 100%; position: fixed; z-index: 999999; opacity: 0.7;";
 
-striped_lines_box.appendChild(inner_text);
+    var inner_text = document.createElement('span');
+    inner_text.textContent = warning_text;
+    inner_text.style.cssText = "font-family: 'Lucida Console', Monaco, monospace; color: white; margin: auto; background: black; display: block; height: 20px; width: 500px; text-align: center; font-size: 14px;";
 
-document.body.insertBefore(striped_lines_box, document.body.firstChild);
+    striped_lines_box.appendChild(inner_text);
+
+    document.body.insertBefore(striped_lines_box, document.body.firstChild);
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Fake News Alert",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "manifest_version": 2,
   "description": "Alerts you if you are viewing a fake news site",
   "homepage_url": "http://nymag.com",
@@ -9,7 +9,16 @@
   },
   "icons": { "128": "icons/icon128.png" },
   "default_locale": "en",
-  
+
+  "options_ui": {
+    "page": "options.html",
+    "chrome_style": true
+  },
+  "options_page": "options.html",
+
+  "permissions": [
+    "storage"
+  ],
 
   "applications": {
     "gecko": {

--- a/options.html
+++ b/options.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Fake News Alert: Options</title>
+</head>
+
+<body>
+  Alert mode:
+  <select id="mode">
+    <option value="banner">Banner</option>
+    <option value="alert">Alert Dialog</option>
+  </select>
+
+  <div id="status"></div>
+  <button id="save">Save</button>
+
+  <script src="options.js"></script>
+</body>
+
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,27 @@
+// Saves options to chrome.storage
+function save_options() {
+  var mode = document.getElementById('mode').value;
+  chrome.storage.sync.set({
+    mode: mode
+  }, function() {
+    // Update status to let user know options were saved.
+    var status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(function() {
+      status.textContent = '';
+    }, 750);
+  });
+}
+
+// Restores select box state using the preferences
+// stored in chrome.storage.
+function restore_options() {
+  // Use default value color = 'red' and likesColor = true.
+  chrome.storage.sync.get({
+    mode: 'banner'
+  }, function(items) {
+    document.getElementById('mode').value = items.mode;
+  });
+}
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click', save_options);


### PR DESCRIPTION
I noticed a review that preferred the alert dialog to the banner, so this pull request allows the user to choose between having alert dialogs pop up or have the banner at the top of the page. Banner is the default option.

I also added a .editorconfig file to ensure the syntax formatting stays the same across all the different editors that support it.