### PR TITLE
Microsoft Edge compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,11 @@
   "manifest_version": 2,
   "description": "Alerts you if you are viewing a fake news site",
   "homepage_url": "http://nymag.com",
+  "author": "Brian Feldman",
   "browser_action": {
-    "default_icon": "icons/icon48.png"
+    "default_icon": {
+      "48": "icons/icon48.png"
+    }
   },
   "icons": { "128": "icons/icon128.png" },
   "default_locale": "en",


### PR DESCRIPTION
This works mostly unmodified in Edge, minus two issues:
- The "author" field can't be blank
- `browser_action.default_icon` is an object whose properties are the icon sizes according to the [Web Extensions Spec](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/browser_action).

Tested in Chrome, Edge, and Firefox and they all seem happy with it! The only hiccup here is that Edge doesn't accept 48px icons, [per the documentation](https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/extensions/api-support/supported-manifest-keys/) so maybe the 48px icon should be shrunk to 40px?